### PR TITLE
[emacs] add missing quotes around $@ expansion

### DIFF
--- a/emacs/default.nix
+++ b/emacs/default.nix
@@ -33,7 +33,7 @@
   home.file."bin/em" = {
     text = ''
       #!/bin/sh
-      emacsclient -nc $@
+      emacsclient -nc "$@"
     '';
     executable = true;
   };


### PR DESCRIPTION
Hi, fellow emacser!

I noticed that your `bin/em` shell script was missing a pair of double quotes around the `$@` expansion.

This can cause grief if you ever try to open a file with spaces on it (rare as those may be).

Allow me to illustrate my point:

```
$ cat bin/em 
#!/bin/bash
echo "Without quotes:"
for file in $@
do
    echo -e "\t$file"
done
echo "With quotes:"
for file in "$@"
do
    echo -e "\t$file"
done
$ bin/em "a filename with spaces on it"
Without quotes:
	a
	filename
	with
	spaces
	on
	it
With quotes:
	a filename with spaces on it
```
Hope that it helps.

Thanks for sharing your config, it's a big help for us aspiring NixOSers!